### PR TITLE
Fix return value

### DIFF
--- a/funcportal/handler.py
+++ b/funcportal/handler.py
@@ -53,7 +53,7 @@ class BaseHandler(object):
             )
             return Response(500, {'error': 'Internal server error.'})
 
-        return Response(200, output_data)
+        return Response(200, {'result': output_data})
 
     def _render_response(self, response):
         status_code = response.status_code

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -8,10 +8,10 @@ import pytest
 
 TEST_MODULE = """
 def multiply(x, y):
-    return {"result": x * y}
+    return x * y
 
 def exponent(base, power=2):
-    return {"result": base ** power}
+    return base ** power
 """
 
 TEST_CONFIG = """


### PR DESCRIPTION
Prior to this PR, funcportal did not return the result of the function in a JSON object as promised in the README. This is now fixed.